### PR TITLE
update gemspec license and authors

### DIFF
--- a/input_sanitizer.gemspec
+++ b/input_sanitizer.gemspec
@@ -3,11 +3,12 @@ $LOAD_PATH.push File.expand_path('../lib', __FILE__)
 require 'input_sanitizer/version'
 
 Gem::Specification.new do |gem|
-  gem.authors       = ["Tomek Paczkowski", "Tomasz Werbicki", "Michal Bugno"]
-  gem.email         = ["tom@futuresimple.com", "tomasz@futuresimple.com", "michal@futuresimple.com"]
+  gem.authors       = ["Zendesk"]
+  gem.email         = ["opensource@zendesk.com"]
   gem.description   = %q{Gem to sanitize hash of incoming data}
   gem.summary       = %q{Gem to sanitize hash of incoming data}
   gem.homepage      = ""
+  gem.license       = "Apache License Version 2.0"
 
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }

--- a/lib/input_sanitizer/version.rb
+++ b/lib/input_sanitizer/version.rb
@@ -1,3 +1,3 @@
 module InputSanitizer
-  VERSION = "0.3.31"
+  VERSION = "0.3.32"
 end


### PR DESCRIPTION
update gemspec with updated license to Apache 2 and use company wide author and email Zendesk and opensource@zendesk.com. to release in rubygems patch version is bumped.